### PR TITLE
Added alert for confirm cancellation of article scheduled status

### DIFF
--- a/app/javascript/src/components/Dashboard/Articles/Article/Alert.jsx
+++ b/app/javascript/src/components/Dashboard/Articles/Article/Alert.jsx
@@ -41,8 +41,9 @@ const Alert = ({ article, formValues, onClose }) => {
   return (
     <NeetoUIAlert
       isOpen
-      message={`This article is scheduled to be ${scheduledStatus} at "${scheduledTime}". Are you sure you want to continue? This will remove the scheduled ${scheduledStatus}.`}
-      title="Removing scheduled article"
+      title="Confirm removal of article scheduled status"
+      message={`This article is scheduled to be ${scheduledStatus} at "${scheduledTime}".
+      Are you sure you want to continue? This will remove the scheduled ${scheduledStatus}.`}
       onClose={onClose}
       onSubmit={handleSubmit}
     />

--- a/app/javascript/src/components/Dashboard/Articles/Article/Edit.jsx
+++ b/app/javascript/src/components/Dashboard/Articles/Article/Edit.jsx
@@ -109,7 +109,11 @@ const Edit = () => {
         refetch={fetchArticle}
         selectedArticle={convertArticleToFormFormat(article)}
       />
-      <VersionHistory article={article} articleVersions={articleVersions} />
+      <VersionHistory
+        article={article}
+        articleVersions={articleVersions}
+        refetch={fetchArticleAndVersions}
+      />
       {showDatePicker && (
         <DatePicker
           isEdit

--- a/app/javascript/src/components/Dashboard/Articles/Article/Form.jsx
+++ b/app/javascript/src/components/Dashboard/Articles/Article/Form.jsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from "react";
 
 import { Formik, Form as FormikForm } from "formik";
 import { Info } from "neetoicons";
-import { Dropdown, Button, PageLoader, Callout } from "neetoui";
+import { Dropdown, Button, PageLoader, Callout, Alert } from "neetoui";
 import { Select, Input, Textarea } from "neetoui/formik";
 import { useHistory } from "react-router-dom";
 
@@ -25,6 +25,7 @@ const Form = ({
     selectedArticle.status === "Published" ? "Publish" : "Save draft"
   );
   const [categories, setCategories] = useState([]);
+  const [showAlert, setShowAlert] = useState(false);
 
   const history = useHistory();
   const { Menu, MenuItem } = Dropdown;
@@ -45,17 +46,41 @@ const Form = ({
     }
   };
 
-  const handleCancelScheduled = async status => {
+  const handleCancelScheduled = async scheduledStatus => {
     try {
-      if (status === "Publish later") {
+      if (
+        scheduledStatus === "Publish later" &&
+        (selectedArticle.status === "Published" ||
+          selectedArticle.scheduledUnpublish === null)
+      ) {
         await articlesApi.update(selectedArticle.id, {
           scheduled_publish: null,
         });
-      } else {
+        refetch();
+      } else if (
+        scheduledStatus === "Unpublish later" &&
+        (selectedArticle.status === "Draft" ||
+          selectedArticle.scheduledPublish === null)
+      ) {
         await articlesApi.update(selectedArticle.id, {
           scheduled_unpublish: null,
         });
+        refetch();
+      } else {
+        setShowAlert(true);
       }
+    } catch (error) {
+      logger.error(error);
+    }
+  };
+
+  const handleCancelScheduledSubmit = async () => {
+    try {
+      await articlesApi.update(selectedArticle.id, {
+        scheduled_publish: null,
+        scheduled_unpublish: null,
+      });
+      setShowAlert(false);
       refetch();
     } catch (error) {
       logger.error(error);
@@ -76,123 +101,138 @@ const Form = ({
   }
 
   return (
-    <Formik
-      initialValues={selectedArticle}
-      validateOnBlur={submitted}
-      validateOnChange={submitted}
-      validationSchema={ARTICLES_FORM_VALIDATION_SCHEMA(CATEGORY_OPTIONS)}
-      onSubmit={handleSubmit}
-    >
-      {({ isSubmitting, setFieldValue, dirty }) => (
-        <FormikForm className="mx-auto mt-8 w-6/12">
-          {selectedArticle.scheduledPublish !== null && (
-            <Callout className="my-2" icon={Info} style="info">
-              <div>
-                This article is scheduled to be published at "
-                {formatTimeStampToTimeAndDate(selectedArticle.scheduledPublish)}
-                ".&nbsp;
-                <span
-                  className="cursor-pointer text-indigo-500"
-                  onClick={() => handleCancelScheduled("Publish later")}
-                >
-                  Click here&nbsp;
-                </span>
-                to cancel publish scheduled.
-              </div>
-            </Callout>
-          )}
-          {selectedArticle.scheduledUnpublish !== null && (
-            <Callout className="my-2" icon={Info} style="warning">
-              <div>
-                This article is scheduled to be Unpublished at "
-                {formatTimeStampToTimeAndDate(
-                  selectedArticle.scheduledUnpublish
-                )}
-                ".&nbsp;
-                <span
-                  className="cursor-pointer text-indigo-500"
-                  onClick={() => handleCancelScheduled("Unpublish later")}
-                >
-                  Click here&nbsp;
-                </span>
-                to cancel unpublish scheduled.
-              </div>
-            </Callout>
-          )}
-          <div className="my-5 flex gap-x-4">
-            <Input
-              required
-              className="mr-3 w-5/12"
-              label="Article Title"
-              name="title"
-              placeholder="Enter Title"
-            />
-            <Select
-              isSearchable
-              required
-              className="w-56"
-              label="Select Category"
-              name="category"
-              options={CATEGORY_OPTIONS}
-              placeholder="Select Category"
-            />
-          </div>
-          <Textarea
-            required
-            label="Article Body"
-            name="body"
-            placeholder="Enter text"
-            rows={30}
-          />
-          <div className="mt-4 flex gap-2">
-            <div className="flex">
-              <Tooltip
-                content="Please make any change to save."
-                disabled={isSubmitting || (isEdit && !dirty)}
-                followCursor="horizontal"
-                position="bottom"
-              >
-                <Button
-                  className="mr-px"
-                  disabled={isSubmitting || (isEdit && !dirty)}
-                  label={status}
-                  loading={isSubmitting}
-                  name="status"
-                  size="medium"
-                  style="primary"
-                  type="submit"
-                  onClick={() => {
-                    setFieldValue("status", status);
-                    setSubmitted(true);
-                  }}
-                />
-              </Tooltip>
-              <Dropdown>
-                <Menu>
-                  {articleStatusList.map((status, idx) => (
-                    <MenuItem.Button
-                      key={idx}
-                      onClick={() => {
-                        setFieldValue("status", status);
-                        setStatus(status);
-                      }}
-                    >
-                      {status}
-                    </MenuItem.Button>
-                  ))}
-                </Menu>
-              </Dropdown>
+    <>
+      <Formik
+        initialValues={selectedArticle}
+        validateOnBlur={submitted}
+        validateOnChange={submitted}
+        validationSchema={ARTICLES_FORM_VALIDATION_SCHEMA(CATEGORY_OPTIONS)}
+        onSubmit={handleSubmit}
+      >
+        {({ isSubmitting, setFieldValue, dirty }) => (
+          <FormikForm className="mx-auto mt-8 w-6/12">
+            {selectedArticle.scheduledPublish !== null && (
+              <Callout className="my-2" icon={Info} style="info">
+                <div>
+                  This article is scheduled to be published at "
+                  {formatTimeStampToTimeAndDate(
+                    selectedArticle.scheduledPublish
+                  )}
+                  ".&nbsp;
+                  <span
+                    className="cursor-pointer text-indigo-500"
+                    onClick={() => handleCancelScheduled("Publish later")}
+                  >
+                    Click here&nbsp;
+                  </span>
+                  to cancel publish scheduled.
+                </div>
+              </Callout>
+            )}
+            {selectedArticle.scheduledUnpublish !== null && (
+              <Callout className="my-2" icon={Info} style="warning">
+                <div>
+                  This article is scheduled to be Unpublished at "
+                  {formatTimeStampToTimeAndDate(
+                    selectedArticle.scheduledUnpublish
+                  )}
+                  ".&nbsp;
+                  <span
+                    className="cursor-pointer text-indigo-500"
+                    onClick={() => handleCancelScheduled("Unpublish later")}
+                  >
+                    Click here&nbsp;
+                  </span>
+                  to cancel unpublish scheduled.
+                </div>
+              </Callout>
+            )}
+            <div className="my-5 flex gap-x-4">
+              <Input
+                required
+                className="mr-3 w-5/12"
+                label="Article Title"
+                name="title"
+                placeholder="Enter Title"
+              />
+              <Select
+                isSearchable
+                required
+                className="w-56"
+                label="Select Category"
+                name="category"
+                options={CATEGORY_OPTIONS}
+                placeholder="Select Category"
+              />
             </div>
-            <Button
-              label="Cancel"
-              style="text"
-              type="reset"
-              onClick={() => history.push("/")}
+            <Textarea
+              required
+              label="Article Body"
+              name="body"
+              placeholder="Enter text"
+              rows={30}
             />
-          </div>
-        </FormikForm>
+            <div className="mt-4 flex gap-2">
+              <div className="flex">
+                <Tooltip
+                  content="Please make any change to save."
+                  disabled={isSubmitting || (isEdit && !dirty)}
+                  followCursor="horizontal"
+                  position="bottom"
+                >
+                  <Button
+                    className="mr-px"
+                    disabled={isSubmitting || (isEdit && !dirty)}
+                    label={status}
+                    loading={isSubmitting}
+                    name="status"
+                    size="medium"
+                    style="primary"
+                    type="submit"
+                    onClick={() => {
+                      setFieldValue("status", status);
+                      setSubmitted(true);
+                    }}
+                  />
+                </Tooltip>
+                <Dropdown>
+                  <Menu>
+                    {articleStatusList.map((status, idx) => (
+                      <MenuItem.Button
+                        key={idx}
+                        onClick={() => {
+                          setFieldValue("status", status);
+                          setStatus(status);
+                        }}
+                      >
+                        {status}
+                      </MenuItem.Button>
+                    ))}
+                  </Menu>
+                </Dropdown>
+              </div>
+              <Button
+                label="Cancel"
+                style="text"
+                type="reset"
+                onClick={() => history.push("/")}
+              />
+            </div>
+          </FormikForm>
+        )}
+      </Formik>
+      {showAlert && (
+        <Alert
+          isOpen
+          title="Confirm removal of article scheduled status"
+          message="This will remove both the scheduled status as the Drafted article
+          cannot be unpublish later without publish later and the Published article
+          cannot be publish later without Unpublish later."
+          onClose={() => setShowAlert(false)}
+          onSubmit={handleCancelScheduledSubmit}
+        />
       )}
-    </Formik>
+    </>
   );
 };
 

--- a/app/javascript/src/components/Dashboard/Articles/Article/VersionHistory/Modal.jsx
+++ b/app/javascript/src/components/Dashboard/Articles/Article/VersionHistory/Modal.jsx
@@ -9,14 +9,11 @@ import {
   Textarea,
   Callout,
 } from "neetoui";
-import { useHistory } from "react-router-dom";
 
 import { articlesApi } from "apis/admin";
 import Tooltip from "components/Common/Tooltip";
 
-const Modal = ({ article, version, showModal, setShowModal }) => {
-  const history = useHistory();
-
+const Modal = ({ article, version, showModal, setShowModal, refetch }) => {
   const categoryValue = version.category
     ? version.category.name
     : "Category doesn't exists.";
@@ -35,7 +32,8 @@ const Modal = ({ article, version, showModal, setShowModal }) => {
         scheduled_unpublish: null,
       };
       await articlesApi.update(version.article.id, articleData);
-      history.go(0);
+      setShowModal(false);
+      refetch();
     } catch (error) {
       logger.error(error);
     }

--- a/app/javascript/src/components/Dashboard/Articles/Article/VersionHistory/index.jsx
+++ b/app/javascript/src/components/Dashboard/Articles/Article/VersionHistory/index.jsx
@@ -7,7 +7,7 @@ import { formatTimeStampToTimeAndDate } from "components/utils";
 import Modal from "./Modal";
 import Versions from "./Versions";
 
-const VersionHistory = ({ article, articleVersions }) => {
+const VersionHistory = ({ article, articleVersions, refetch }) => {
   const [showModal, setShowModal] = useState(false);
   const [version, setVersion] = useState({});
 
@@ -44,6 +44,7 @@ const VersionHistory = ({ article, articleVersions }) => {
       {showModal && (
         <Modal
           article={article}
+          refetch={refetch}
           setShowModal={setShowModal}
           showModal={showModal}
           version={version}

--- a/app/javascript/src/components/Dashboard/Articles/Table/utils.jsx
+++ b/app/javascript/src/components/Dashboard/Articles/Table/utils.jsx
@@ -1,10 +1,14 @@
 import React from "react";
 
 import { Delete, Edit } from "neetoicons";
-import { Typography, Button } from "neetoui";
+import { Typography, Button, Kbd } from "neetoui";
 import { Link } from "react-router-dom";
 
-import { formatTimeStampToDate } from "components/utils";
+import Tooltip from "components/Common/Tooltip";
+import {
+  formatTimeStampToDate,
+  formatTimeStampToTimeAndDate,
+} from "components/utils";
 
 import { ColumnListItems } from "../constants";
 
@@ -52,7 +56,7 @@ export const buildArticleTableColumnData = handleDelete => {
       title: "Author",
       dataIndex: "author",
       key: "author",
-      width: "20%",
+      width: "15%",
       render: author => (
         <Typography className="text-gray-600" style="h5">
           {author.name}
@@ -74,11 +78,43 @@ export const buildArticleTableColumnData = handleDelete => {
       title: "Status",
       dataIndex: "status",
       key: "status",
-      width: "15%",
-      render: status => (
-        <Typography className="text-gray-600" style="h5">
-          {status}
-        </Typography>
+      width: "20%",
+      render: (
+        status,
+        {
+          scheduled_publish: scheduledPublish,
+          scheduled_unpublish: scheduledUnpublish,
+        }
+      ) => (
+        <div className="flex space-x-2">
+          <Typography className="mt-1 text-gray-600" style="h5">
+            {status}
+          </Typography>
+          {scheduledPublish !== null && (
+            <Tooltip
+              disabled
+              followCursor="horizontal"
+              position="top"
+              content={`Publish scheduled at ${formatTimeStampToTimeAndDate(
+                scheduledPublish
+              )}`}
+            >
+              <Kbd className="h-4" keyName="P" />
+            </Tooltip>
+          )}
+          {scheduledUnpublish !== null && (
+            <Tooltip
+              disabled
+              followCursor="horizontal"
+              position="top"
+              content={`Unpublish scheduled at ${formatTimeStampToTimeAndDate(
+                scheduledUnpublish
+              )}`}
+            >
+              <Kbd className="h-4" keyName="UP" />
+            </Tooltip>
+          )}
+        </div>
       ),
     },
   ];
@@ -88,7 +124,15 @@ export const buildArticleTableColumnData = handleDelete => {
     dataIndex: "id",
     key: "option",
     width: "10%",
-    render: (_, { id, title, scheduled_publish, scheduled_unpublish }) => (
+    render: (
+      _,
+      {
+        id,
+        title,
+        scheduled_publish: scheduledPublish,
+        scheduled_unpublish: scheduledUnpublish,
+      }
+    ) => (
       <div className="flex items-end">
         <Button
           icon={Delete}
@@ -98,8 +142,8 @@ export const buildArticleTableColumnData = handleDelete => {
             handleDelete({
               title,
               id,
-              scheduledPublish: scheduled_publish,
-              scheduledUnpublish: scheduled_unpublish,
+              scheduledPublish,
+              scheduledUnpublish,
             })
           }
         />


### PR DESCRIPTION
fixes #349 
Fixed edge case of cancellation of publish later article which also has unpublish later and status is draft.
Fixed edge case of cancellation of unpublish later article which also has publish later and status is published.
Made changes in the status UI of the articles table to show publish later and unpublish later information with a tooltip.